### PR TITLE
Fixed opencv version that resulted in compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1369,7 +1369,7 @@ sudo apt-get install # OpenGL support [TODO]
 sudo ldconfig -v
 
 # Get OpenCV
-wget https://github.com/Itseez/opencv/archive/3.0.0-rc1.zip -O opencv.zip
+wget https://github.com/Itseez/opencv/archive/3.1.0.zip -O opencv.zip
 unzip opencv.zip -d opencv
 
 # Build OpenCV


### PR DESCRIPTION
OpenCV version 3.0.0 does not work, reproduced across computers and users. Version 3.1.0 fixes opencv-related issues during compilation