### PR TITLE
Interactive recording: Ensure thread is joined.

### DIFF
--- a/src/recorder/main.cpp
+++ b/src/recorder/main.cpp
@@ -328,12 +328,15 @@ int main(int argc, char *argv[]) {
 
                     // Start recording in background
                     std::thread process(run, std::ref(recorder));
-
-                    // Interact using stdin
-                    oat::printInteractiveUsage(std::cout);
-                    rc = oat::controlRecorder(std::cin, std::cout, *recorder, true);
-
-                    // Interrupt and join threads
+                    try {
+                      // Interact using stdin
+                      oat::printInteractiveUsage(std::cout);
+                      rc = oat::controlRecorder(std::cin, std::cout, *recorder, true);
+                    } catch (...) {
+                      // Interrupt and join threads
+                      cleanup(process);
+                      throw;
+                    }
                     cleanup(process);
 
                     break;


### PR DESCRIPTION
The destructor of std::thread will call std::terminate if the thread is
still running and is joinable.